### PR TITLE
Change image tag to be date instead of git commit

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,7 @@ phases:
       - . ./extras.sh
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
       - CODEBUILD_RESOLVED_SOURCE_VERSION="${CODEBUILD_RESOLVED_SOURCE_VERSION:-$IMAGE_TAG}"
-      - IMAGE_TAG=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=$(date +%Y%m%d%H%M%S)
       - IMAGE_URI="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$IMAGE_REPO_NAME"
   build:
     commands:


### PR DESCRIPTION
Since we're building these images once a day, makes more sense to use a timestamp rather than a git commit. Either way, latest will be the preferred tag to use.